### PR TITLE
Upgrading to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Build stage for compiling Zandronum
-FROM ubuntu:19.10 AS build
+FROM ubuntu:20.04 AS build
 WORKDIR /build
+ENV DEBIAN_FRONTEND=noninteractive
 RUN true \
     && apt-get update -qq \
     && apt-get install -qq --no-install-recommends \
@@ -57,7 +58,7 @@ COPY docker-files/GeoLite2-Country.mmdb "$INSTALL_DIR/GeoIP.dat"
 
 # Final stage for running the zandronum server.
 # Copies over everything in /usr/local.
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 COPY --from=build /usr/local/ /usr/local/
 RUN true \
     && apt-get update -qq \


### PR DESCRIPTION
Hi there. Thanks for making this Zandronum container. I've upgraded to Ubuntu 20.04 and verified that it does launch and serve games. I added `ENV DEBIAN_FRONTEND=noninteractive` and `apt-utils` since not having them there was causing the build to fail with the upgrade.